### PR TITLE
Debug stage3: fix two bugs in `buf.C`, passing all the provided tests.

### DIFF
--- a/stage3/buf.C
+++ b/stage3/buf.C
@@ -328,7 +328,7 @@ const Status BufMgr::allocPage(File *file, int &pageNo, Page *&page) {
 
   bufTable[frameNo].Set(file, pageNo);
   // iffy on this line
-  page = &bufPool[pageNo];
+  page = &bufPool[frameNo];
   return OK;
 }
 

--- a/stage3/buf.C
+++ b/stage3/buf.C
@@ -248,13 +248,6 @@ const Status BufMgr::readPage(File *file, const int pageNo, Page *&page) {
       // If insertion fails, return the error.
       return status;
     }
-
-    // Increment the pin count since the page is now being used.
-    bufTable[frameNo].pinCnt++;
-
-    // Set the reference bit.
-    bufTable[frameNo].refbit = true;
-
     return OK;
   } else {
     // If the lookup returned an error other than HASHNOTFOUND, return that

--- a/stage3/buf.C
+++ b/stage3/buf.C
@@ -1,14 +1,12 @@
-#include "buf.h"
-#include "error.h"
-#include "page.h"
+#include <memory.h>
+#include <unistd.h>
 #include <errno.h>
+#include <stdlib.h>
 #include <fcntl.h>
 #include <iostream>
-#include <memory.h>
 #include <stdio.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include <utility>
+#include "page.h"
+#include "buf.h"
 
 // if error condition is met, trigger an early return with a specified error
 #define ERR_RET(cond, err)                                                     \

--- a/stage3/buf.C
+++ b/stage3/buf.C
@@ -200,99 +200,105 @@ const Status BufMgr::allocBuf(int &frame) {
 }
 
 const Status BufMgr::readPage(File *file, const int pageNo, Page *&page) {
-    Status status;
-    int frameNo;
+  Status status;
+  int frameNo;
 
-    // First, check if the page is already in the buffer pool by looking it up in the hash table.
-    status = hashTable->lookup(file, pageNo, frameNo);
+  // First, check if the page is already in the buffer pool by looking it up in
+  // the hash table.
+  status = hashTable->lookup(file, pageNo, frameNo);
 
-    if (status == OK) {
-        // If found, point the page pointer to the appropriate page in the buffer pool.
-        page = &bufPool[frameNo];
+  if (status == OK) {
+    // If found, point the page pointer to the appropriate page in the buffer
+    // pool.
+    page = &bufPool[frameNo];
 
-        // Increment the pin count for the page as it is now being used.
-        bufTable[frameNo].pinCnt++;
+    // Increment the pin count for the page as it is now being used.
+    bufTable[frameNo].pinCnt++;
 
-        // Mark the reference bit as true, indicating that the page has been accessed.
-        bufTable[frameNo].refbit = true;
+    // Mark the reference bit as true, indicating that the page has been
+    // accessed.
+    bufTable[frameNo].refbit = true;
 
-        return OK;
-    } else if (status == HASHNOTFOUND) {
-        // If the page is not in the buffer pool, allocate a frame for it.
-        status = allocBuf(frameNo);
-        if (status != OK) {
-            // If unable to allocate a buffer, return the error (could be BUFFEREXCEEDED or UNIXERR).
-            return status;
-        }
-
-        // Load the page into the buffer pool frame.
-        status = file->readPage(pageNo, &bufPool[frameNo]);
-        if (status != OK) {
-            // If reading the page fails, return the error.
-            return status;
-        }
-
-        // Point the page pointer to the new page in the buffer pool.
-        page = &bufPool[frameNo];
-
-        // Update the buffer descriptor for the new page.
-        bufTable[frameNo].Set(file, pageNo);
-
-        // Insert the page into the hash table so it can be found next time.
-        status = hashTable->insert(file, pageNo, frameNo);
-        if (status != OK) {
-            // If insertion fails, return the error.
-            return status;
-        }
-
-        // Increment the pin count since the page is now being used.
-        bufTable[frameNo].pinCnt++;
-
-        // Set the reference bit.
-        bufTable[frameNo].refbit = true;
-
-        return OK;
-    } else {
-        // If the lookup returned an error other than HASHNOTFOUND, return that error.
-        return status;
+    return OK;
+  } else if (status == HASHNOTFOUND) {
+    // If the page is not in the buffer pool, allocate a frame for it.
+    status = allocBuf(frameNo);
+    if (status != OK) {
+      // If unable to allocate a buffer, return the error (could be
+      // BUFFEREXCEEDED or UNIXERR).
+      return status;
     }
+
+    // Load the page into the buffer pool frame.
+    status = file->readPage(pageNo, &bufPool[frameNo]);
+    if (status != OK) {
+      // If reading the page fails, return the error.
+      return status;
+    }
+
+    // Point the page pointer to the new page in the buffer pool.
+    page = &bufPool[frameNo];
+
+    // Update the buffer descriptor for the new page.
+    bufTable[frameNo].Set(file, pageNo);
+
+    // Insert the page into the hash table so it can be found next time.
+    status = hashTable->insert(file, pageNo, frameNo);
+    if (status != OK) {
+      // If insertion fails, return the error.
+      return status;
+    }
+
+    // Increment the pin count since the page is now being used.
+    bufTable[frameNo].pinCnt++;
+
+    // Set the reference bit.
+    bufTable[frameNo].refbit = true;
+
+    return OK;
+  } else {
+    // If the lookup returned an error other than HASHNOTFOUND, return that
+    // error.
+    return status;
+  }
 }
 
-
 const Status BufMgr::unPinPage(File *file, const int PageNo, const bool dirty) {
-    int frameNo;
-    Status status = hashTable->lookup(file, PageNo, frameNo); // Lookup the frame number
-    if (status != OK) {
-        // Handle the error, e.g., if the page is not found in the hash table.
-        return status;
-    }
+  int frameNo;
+  Status status =
+      hashTable->lookup(file, PageNo, frameNo); // Lookup the frame number
+  if (status != OK) {
+    // Handle the error, e.g., if the page is not found in the hash table.
+    return status;
+  }
 
-    // Assuming lookup was successful, we now have the frame number in frameNo.
-    BufDesc* bufDesc = &bufTable[frameNo]; // Get the buffer descriptor for the frame.
+  // Assuming lookup was successful, we now have the frame number in frameNo.
+  BufDesc *bufDesc =
+      &bufTable[frameNo]; // Get the buffer descriptor for the frame.
 
-    // Check if the frame is actually pinned.
-    if (bufDesc->pinCnt <= 0) {
-        return PAGENOTPINNED; // or some other appropriate error handling
-    }
+  // Check if the frame is actually pinned.
+  if (bufDesc->pinCnt <= 0) {
+    return PAGENOTPINNED; // or some other appropriate error handling
+  }
 
-    // Decrement the pin count as the page is being unpinned.
-    bufDesc->pinCnt--;
+  // Decrement the pin count as the page is being unpinned.
+  bufDesc->pinCnt--;
 
-    // If the dirty parameter is true, set the dirty bit for the frame.
-    if (dirty) {
-        bufDesc->dirty = true;
-    }
-    
-    return OK;
+  // If the dirty parameter is true, set the dirty bit for the frame.
+  if (dirty) {
+    bufDesc->dirty = true;
+  }
+
+  return OK;
 }
 
 /*
     @param: file    A file pointer that we will use to allocate teh page into
-    @param pageNo   A reference int that we will return the page number of the newly
-                    alloced page
+    @param pageNo   A reference int that we will return the page number of the
+   newly alloced page
     @param page     A pinter to the newly alloced page
-    @return A status indicating whether the operation finished successfully (OK) or
-            had some error associated with it (UNIXERROR/HASHTBLERROR/BUFFEREXCEEDED)
+    @return A status indicating whether the operation finished successfully (OK)
+   or had some error associated with it (UNIXERROR/HASHTBLERROR/BUFFEREXCEEDED)
 */
 const Status BufMgr::allocPage(File *file, int &pageNo, Page *&page) {
   if (file == nullptr)
@@ -317,9 +323,9 @@ const Status BufMgr::allocPage(File *file, int &pageNo, Page *&page) {
 
   // The BufDesc class is used to keep track of the state of each frame in the
   // buffer pool. thus we have to update the correct frame in the buff table
-  if (bufTable == nullptr) 
+  if (bufTable == nullptr)
     return UNIXERR;
-  
+
   bufTable[frameNo].Set(file, pageNo);
   // iffy on this line
   page = &bufPool[pageNo];

--- a/stage3/makefile
+++ b/stage3/makefile
@@ -9,10 +9,10 @@
 #
 
 LD =		ld
-LDFLAGS =	
+LDFLAGS =	-fsanitize=undefined -fsanitize=address
 
 CXX =           g++
-CXXFLAGS =	-g -Wall -Wextra
+CXXFLAGS =	-g -Wall -Wextra -Wno-ignored-qualifiers -fsanitize=undefined -fsanitize=address
 
 PURIFY =        purify -collector=/usr/ccs/bin/ld -g++
 


### PR DESCRIPTION
- In `BufMgr::allocPage()` method: index buffer pool with frame number rather than page number (which should be used for disk file representation)
- In `BufMgr::readPage()` method: if the page does not present in buffer and we just loaded it, set the pin count to 1. Previously it was set to 2.